### PR TITLE
Fix for royal jelly addiction hediff logging error every tick.

### DIFF
--- a/Source/PawnmorphInsects/PawnmorphInsects/PMI_InsectJellyWithdraw.cs
+++ b/Source/PawnmorphInsects/PawnmorphInsects/PMI_InsectJellyWithdraw.cs
@@ -12,6 +12,9 @@ namespace PawnmorphInsects
 {
     public class PMI_InsectJellyWithdraw : Hediff_Addiction
     {
+        /// <summary>
+        /// False if the pawn has already been transformed once and then reverted.
+        /// </summary>
         bool firstTime = true;
 
         public override void ExposeData()
@@ -27,6 +30,13 @@ namespace PawnmorphInsects
             Need_Chemical need = this.Need;
             if (firstTime && need != null && need.CurCategory == DrugDesireCategory.Withdrawal)
             {
+                // Check every 30 ticks
+                if (pawn.IsHashIntervalTick(30) == false)
+                    return;
+
+                // If pawn is not available to be transformed.
+                if (MutagenDefOf.defaultMutagen.MutagenCached.CanTransform(pawn) == false)
+                    return;
 
                 Name colonistName = this.pawn.Name;
                 var tfRequest = new TransformationRequest(PawnKindDefOf.Megaspider, pawn);
@@ -35,9 +45,7 @@ namespace PawnmorphInsects
                 if (tfPawn == null)
                 {
                     Log.Error($"unable to transform pawn {colonistName}");
-                    firstTime = false;
                     return;
-
                 }
 
                 Find.World.GetComponent<PawnmorphGameComp>().AddTransformedPawn(tfPawn);
@@ -46,8 +54,8 @@ namespace PawnmorphInsects
 
                 string text = "TransformationLetter".Translate(colonistName).CapitalizeFirst();
                 Find.LetterStack.ReceiveLetter("TransformationLLabel".Translate(colonistName).CapitalizeFirst(), text, LetterDefOf.NegativeEvent, megaspider, null, null);
+                firstTime = false;
             }
-            this.firstTime = false;
         }
     }
 }

--- a/Source/PawnmorphInsects/PawnmorphInsects/PMI_InsectJellyWithdraw.cs
+++ b/Source/PawnmorphInsects/PawnmorphInsects/PMI_InsectJellyWithdraw.cs
@@ -25,7 +25,7 @@ namespace PawnmorphInsects
         {
             base.Tick();
             Need_Chemical need = this.Need;
-            if (need != null && need.CurCategory == DrugDesireCategory.Withdrawal)
+            if (firstTime && need != null && need.CurCategory == DrugDesireCategory.Withdrawal)
             {
 
                 Name colonistName = this.pawn.Name;


### PR DESCRIPTION
Should fix - if not prevent - the "error every tick" described in this issue:
https://github.com/Tachyonite/PawnmorpherInsects/issues/309

I do not understand the exact root cause of the issue but it seems to be related to Withdrawal hediff still ticking on world pawns.
This change should at least ensure that they won't be transformed again from the same addiction if reverted and ensure the pawn is available to transform before trying.

And should everything fail, then it will only check at most every 30 frames.